### PR TITLE
Methods for handling '/users' actions from event_log_store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# IDE
+.idea/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    action_tracker_client (0.1.1)
+    action_tracker_client (0.1.2)
       activemodel (>= 4.0)
       activesupport (>= 4.0)
       api_signature (~> 0.1.5)
@@ -12,13 +12,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.3)
-      activesupport (= 5.2.3)
-    activesupport (5.2.3)
+    activemodel (6.0.0)
+      activesupport (= 6.0.0)
+    activesupport (6.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 2.1, >= 2.1.8)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     api_signature (0.1.5)
@@ -56,10 +57,10 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (0.3.9)
-    httparty (0.17.0)
+    httparty (0.17.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.6.0)
+    i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     listen (3.1.5)
@@ -68,10 +69,10 @@ GEM
       ruby_dep (~> 1.2)
     lumberjack (1.0.13)
     method_source (0.9.2)
-    mime-types (3.2.2)
+    mime-types (3.3)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
-    minitest (5.11.3)
+    mime-types-data (3.2019.0904)
+    minitest (5.12.2)
     model_auditor (0.0.2)
     multi_xml (0.6.0)
     nenv (0.3.0)
@@ -119,6 +120,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    zeitwerk (2.1.10)
 
 PLATFORMS
   ruby
@@ -133,4 +135,4 @@ DEPENDENCIES
   webmock (~> 3.5, >= 3.5.1)
 
 BUNDLED WITH
-   1.16.2
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    action_tracker_client (0.1.2)
+    action_tracker_client (0.1.1)
       activemodel (>= 4.0)
       activesupport (>= 4.0)
       api_signature (~> 0.1.5)
@@ -12,14 +12,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.0.0)
-      activesupport (= 6.0.0)
-    activesupport (6.0.0)
+    activemodel (5.2.3)
+      activesupport (= 5.2.3)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.1, >= 2.1.8)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     api_signature (0.1.5)
@@ -57,10 +56,10 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (0.3.9)
-    httparty (0.17.1)
+    httparty (0.17.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.7.0)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     listen (3.1.5)
@@ -69,10 +68,10 @@ GEM
       ruby_dep (~> 1.2)
     lumberjack (1.0.13)
     method_source (0.9.2)
-    mime-types (3.3)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0904)
-    minitest (5.12.2)
+    mime-types-data (3.2019.0331)
+    minitest (5.11.3)
     model_auditor (0.0.2)
     multi_xml (0.6.0)
     nenv (0.3.0)
@@ -120,7 +119,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    zeitwerk (2.1.10)
 
 PLATFORMS
   ruby
@@ -135,4 +133,4 @@ DEPENDENCIES
   webmock (~> 3.5, >= 3.5.1)
 
 BUNDLED WITH
-   1.17.3
+   1.16.2

--- a/README.md
+++ b/README.md
@@ -62,6 +62,25 @@ end
 #<ActionTracker::Models::TransitionRecord:0x00007f9584d3dfd0 @id="810b900d-d24b-4206-85e3-b7a53e55a060"...
 ```
 
+### Records filtered by user
+```ruby
+api = ActionTracker::Models::TransitionRecord.new
+data = api.filtered_by_users(user_id: user.id, target_id: order.id, target_type: 'Order', per_page: 25, cursor: 'Y3VycmVudF9wYWdl')
+
+#<ActionTracker::CollectionProxy:0x00007f958b6970a8
+# ...
+
+data.each do |record|
+  puts record.inspect
+end
+
+#<ActionTracker::Models::TransitionRecord:0x00007f9584d44470 @id="a51b2fe2-fa92-4e91-bdcd-5beee9081903"...
+#<ActionTracker::Models::TransitionRecord:0x00007f9584d3dfd0 @id="810b900d-d24b-4206-85e3-b7a53e55a060"...
+
+# data = api.filtered_by_users_count(user_id: user.id, target_id: order.id, target_type: 'Order')
+# this will return count of actions 
+```
+
 ### Writing records
 
 Call ActionTracker::Recorder after creating or updating your model:

--- a/lib/action_tracker/models/transition_record.rb
+++ b/lib/action_tracker/models/transition_record.rb
@@ -32,23 +32,20 @@ module ActionTracker
 
       def index(params = {})
         path = processed_path(collection_path, params)
-        @response ||= Connection.new.get(path)
 
-        ActionTracker::CollectionProxy.new @response, self.class.model_name
+        parse_response(path)
       end
 
       def filtered_by_users(params = {})
         path = processed_path(users(params[:user_id]), params.except(:user_id))
-        @response ||= Connection.new.get(path)
 
-        ActionTracker::CollectionProxy.new @response, self.class.model_name
+        parse_response(path)
       end
 
       def filtered_by_users_count(params = {})
         path = processed_path(users(params[:user_id]) + '/count', params.except(:user_id))
-        @response ||= Connection.new.get(path)
 
-        ActionTracker::CollectionProxy.new @response, self.class.model_name
+        parse_response(path)
       end
 
       def collection_path
@@ -72,6 +69,12 @@ module ActionTracker
       end
 
       private
+
+      def parse_response(path)
+        @response ||= Connection.new.get(path)
+
+        ActionTracker::CollectionProxy.new @response, self.class.model_name
+      end
 
       def check_payload
         return if payload.valid?

--- a/spec/action_tracker/utils/connection_spec.rb
+++ b/spec/action_tracker/utils/connection_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe ActionTracker::Connection do
       .with(body: hash_including('params' => 'test'))
   end
 
+  def users_request_stub
+    stub_request(:get, Regexp.new('/api/v1/users'))
+      .with(body: hash_including('params' => 'test'))
+  end
+
   [:get, :post, :put, :patch, :delete].each do |request_method|
     it "should perform `#{request_method}` request" do
       stub = request_stub(request_method)
@@ -18,5 +23,13 @@ RSpec.describe ActionTracker::Connection do
 
       expect(stub).to have_been_requested.once
     end
+  end
+
+  it 'should perform get request to users' do
+    stub = users_request_stub
+
+    connection.send(:get, 'users/1', body: { params: :test })
+
+    expect(stub).to have_been_requested.once
   end
 end


### PR DESCRIPTION
Добавил новый контроллер в event_log_store под названием /users. Соответственно добавил в этот гем методы для обращения к этому контроллеру. 
Метод filter_by_users - должен возвращать все транзишены для конкретного юзера.
Метод filter_by_users_count - должен возвращать count транзишенов для конкретного юзера.