### PR TITLE
Add created_at to form options

### DIFF
--- a/lib/action_tracker/models/transition_record.rb
+++ b/lib/action_tracker/models/transition_record.rb
@@ -48,6 +48,12 @@ module ActionTracker
         request(path)
       end
 
+      def filtered_by_users_simple_count(params = {})
+        path = processed_path(users(params[:user_id]) + '/without_lambda_count', params.except(:user_id))
+
+        request(path)
+      end
+
       def payload
         super.presence || @payload = ActionTracker::Models::Payload.new
       end

--- a/lib/action_tracker/templates/base_template.rb
+++ b/lib/action_tracker/templates/base_template.rb
@@ -13,7 +13,8 @@ module ActionTracker
       def form
         @form ||= ActionTracker::Models::TransitionRecord.new(
           payload: payload,
-          reference: reference
+          reference: reference,
+          created_at: created_at
         ).with_target(target)
       end
 
@@ -56,6 +57,10 @@ module ActionTracker
 
       def title_append
         options[:title_append]
+      end
+
+      def created_at
+        options[:created_at] || Time.zone.now
       end
 
       def reference

--- a/lib/action_tracker/templates/base_template.rb
+++ b/lib/action_tracker/templates/base_template.rb
@@ -60,7 +60,7 @@ module ActionTracker
       end
 
       def created_at
-        options[:created_at] || Time.zone.now
+        options[:created_at] || Time.zone&.now
       end
 
       def reference

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'webmock/rspec'
 require 'pry-byebug'
 
 RSpec.configure do |config|
+  Time.zone = ActiveSupport::TimeZone.all.first
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
 


### PR DESCRIPTION
Добавил поле created_at в форму, из которой строится транзишен для отправки в базу данных воркером. Сделано для того, что бы, если воркер завис или долго стоит в очереди, в базу данных все равно попала правильная дата, а не та дата, когда воркер все таки заработает.